### PR TITLE
#33 커스텀 로거, request 로깅 미들웨어 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { ClassSerializerInterceptor, Module, ValidationPipe } from '@nestjs/common';
+import { ClassSerializerInterceptor, MiddlewareConsumer, Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_PIPE, APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -6,6 +6,8 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { CampaignModule } from './campaign/campain.module';
 import { ParsingEventModule } from './library/parsing-event/parsing-event.module';
+import { HttpLoggerMiddleware } from './library/middleware/http-logger/http-logger.middleware';
+import { CustomLoggerModule } from './library/custom-logger/custom-logger.module';
 
 @Module({
   imports: [
@@ -18,6 +20,7 @@ import { ParsingEventModule } from './library/parsing-event/parsing-event.module
     CampaignModule,
     ScheduleModule.forRoot(),
     ParsingEventModule,
+    CustomLoggerModule,
   ],
   controllers: [],
   providers: [
@@ -34,4 +37,8 @@ import { ParsingEventModule } from './library/parsing-event/parsing-event.module
     },
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(HttpLoggerMiddleware).forRoutes('*');
+  }
+}

--- a/src/library/custom-logger/custom-logger.module.ts
+++ b/src/library/custom-logger/custom-logger.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ParseEventLogger } from './parse-event-logger/parse-event.logger';
+import { HttpLogger } from './http-logger/http.logger';
 
 @Module({
   imports: [PrismaModule],
-  providers: [ParseEventLogger],
-  exports: [ParseEventLogger],
+  providers: [ParseEventLogger, HttpLogger],
+  exports: [ParseEventLogger, HttpLogger],
 })
 export class CustomLoggerModule {}

--- a/src/library/custom-logger/http-logger/http.logger.ts
+++ b/src/library/custom-logger/http-logger/http.logger.ts
@@ -1,0 +1,29 @@
+import { ConsoleLogger, Injectable } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { DateTime } from 'luxon';
+
+@Injectable()
+export class HttpLogger extends ConsoleLogger {
+  log(message: string, context?: string) {
+    const kstTime = DateTime.utc().plus({ hours: 9 }).toISO();
+    console.log(`${kstTime} - [${context}] ${message}`);
+  }
+
+  error(message: string, error: any, context?: string) {
+    const kstTime = DateTime.utc().plus({ hours: 9 }).toISO();
+    console.error(`${kstTime} - [${context}] ${message}`);
+
+    if (error) {
+      switch (true) {
+        case error instanceof AxiosError: {
+          console.error({ request: error.config, response: error.response?.data });
+          break;
+        }
+        default: {
+          console.error(error);
+          break;
+        }
+      }
+    }
+  }
+}

--- a/src/library/middleware/http-logger/http-logger.middleware.ts
+++ b/src/library/middleware/http-logger/http-logger.middleware.ts
@@ -1,0 +1,16 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class HttpLoggerMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const ip = req.ips.length ? req.ips[0] : req.ip;
+    const { method, originalUrl, httpVersion } = req;
+    const userAgent = req.get('user-agent') || '';
+    res.on('finish', () => {
+      const { statusCode } = res;
+      Logger.log(`[${ip}] ${method} ${statusCode} ${originalUrl} HTTP/${httpVersion} ${userAgent}`, 'HttpLoggerMiddleware');
+    });
+    next();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,10 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { HttpLogger } from './library/custom-logger/http-logger/http.logger';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
   const configService = app.get<ConfigService>(ConfigService);
 
   const servicePort = configService.getOrThrow<number>('SERVICE_PORT');
@@ -23,6 +24,7 @@ async function bootstrap() {
   SwaggerModule.setup('api', app, document, { customSiteTitle: 'Muzi API' });
 
   app.use(cookieParser());
+  app.useLogger(app.get(HttpLogger));
 
   await app.listen(servicePort);
 }


### PR DESCRIPTION
## 작업 내역
- 전체 서비스로직에서 사용할 수 있는 httpLogger 프로바이더 추가
- httpLogger를 기본 Logger로 설정
- HTTP Request 요청을 기록하는 middleware 추가


resolve #33